### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/sample"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so Dependabot opens weekly PRs for non-major bumps in addition to its default security-only behavior.
- Registers the root pnpm package and `sample/`, grouping minor/patch updates into a single PR per ecosystem to keep noise down.

## Test plan
- [ ] After merge, confirm Dependabot picks up the config (Insights → Dependency graph → Dependabot).
- [ ] First scheduled PR appears within a week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)